### PR TITLE
Use packed storage for Bid (and other small cleanups)

### DIFF
--- a/packages/contracts/contracts/models/BidModel.sol
+++ b/packages/contracts/contracts/models/BidModel.sol
@@ -8,9 +8,9 @@ pragma solidity 0.8.10;
  */
 abstract contract BidModel {
     struct Bid {
-        uint256 bidderID;
-        uint256 amount;
-        uint256 discount;
+        uint32 bidderID;
+        uint96 amount;
+        uint96 discount;
         WinType winType;
         bool claimed;
     }

--- a/packages/contracts/test/contracts/AuctionRaffle.test.ts
+++ b/packages/contracts/test/contracts/AuctionRaffle.test.ts
@@ -34,7 +34,7 @@ describe('AuctionRaffle', function () {
   let auctionRaffleAsOwner: AuctionRaffleMock
   let bidderAddress: string
   let wallets: Wallet[]
-  let discountTree: MerkleTree 
+  let discountTree: MerkleTree
   let discounts
   let bidderProof: string[]
 
@@ -44,8 +44,8 @@ describe('AuctionRaffle', function () {
     bidderAddress = await auctionRaffle.signer.getAddress()
     bidderProof = discountTree.getHexProof(hashDiscount(bidderAddress, discounts[0]))
   })
-  
-  it.only('should handle the load with 500 participants (TAKES A LONG TIME)', async function () {
+
+  it.skip('should handle the load with 500 participants (TAKES A LONG TIME)', async function () {
     this.timeout(500000);
 
     ({ provider, auctionRaffle, wallets, discountTree, discounts } = await loadFixture(configuredAuctionRaffleFixture({

--- a/packages/contracts/test/contracts/AuctionRaffle.test.ts
+++ b/packages/contracts/test/contracts/AuctionRaffle.test.ts
@@ -565,7 +565,7 @@ describe('AuctionRaffle', function () {
         for (let i = 1; i <= 4; i++) {
           const bid = await getBidByID(i)
 
-          if (bid.bidderID.eq(3)) {
+          if (bid.bidderID == 3) {
             expect(bid.winType).to.be.eq(WinType.goldenTicket)
           } else {
             expect(bid.winType).to.be.eq(WinType.raffle)

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -8,8 +8,23 @@
     <link rel="preload" as="font" crossorigin type="font/woff2" href="/src/styles/fonts/Roboto/Roboto-Bold.woff2" >
     <link rel="preload" as="font" crossorigin type="font/woff2" href="/src/styles/fonts/SpaceMono/SpaceMono-Regular.woff2">
     <link rel="preload" as="font" crossorigin type="font/woff2" href="/src/styles/fonts/SpaceMono/SpaceMono-Bold.woff2">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>EthCC[6] Auction & Raffle Ticket Sale</title>
+    <meta name="viewport" content="width=768px, initial-scale=1" />
+    <!-- Primary Meta Tags -->
+    <title>EthCC[6] Auction & Raffle</title>
+    <meta name="title" content="EthCC[6] Auction & Raffle">
+    <meta name="description" content="EthCC[6] Auction / Raffle -- 25th - 31st March 2023 -- Get your ticket to EthCC">
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://raffle.ethcc.io/">
+    <meta property="og:title" content="EthCC[6] Auction & Raffle">
+    <meta property="og:description" content="EthCC[6] Auction / Raffle -- 25th - 31st March 2023 -- Get your ticket to EthCC">
+    <meta property="og:image" content=""> <!-- TODO: put proper image in place! -->
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://raffle.ethcc.io/">
+    <meta property="twitter:title" content="EthCC[6] Auction & Raffle">
+    <meta property="twitter:description" content="EthCC[6] Auction / Raffle -- 25th - 31st March 2023 -- Get your ticket to EthCC">
+    <meta property="twitter:image" content=""> <!-- TODO: put proper image in place! -->
   </head>
   <body>
     <div id="root"></div>

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -47,7 +47,8 @@
     "set-interval-async": "^2.0.3",
     "siwe": "^1.1.6",
     "styled-components": "^5.3.3",
-    "use-async-effect": "^2.2.5"
+    "use-async-effect": "^2.2.5",
+    "usehooks-ts": "^2.9.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.11",

--- a/packages/frontend/src/components/Auction/Auction.tsx
+++ b/packages/frontend/src/components/Auction/Auction.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 
 export const Auction = () => {
   return (
-    <Wrapper>
+    <Wrapper id="wrapper">
       <UserActionSection />
       <BidsListSection />
     </Wrapper>
@@ -18,4 +18,10 @@ const Wrapper = styled.div`
   width: 670px;
   padding: 0 115px;
   background: ${Colors.GreyLight};
+
+  @media only screen and (max-width: 800px) {
+    width: 100%;
+    padding-left: 32px;
+    padding-right: 32px;
+  }
 `

--- a/packages/frontend/src/components/Auction/UserActionSection.tsx
+++ b/packages/frontend/src/components/Auction/UserActionSection.tsx
@@ -55,4 +55,11 @@ const Wrapper = styled.div`
   background-color: ${Colors.Blue};
   position: relative;
   z-index: 1;
+
+  @media only screen and (max-width: 800px) {
+    display: block;
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+  }
 `

--- a/packages/frontend/src/components/Form/Form.tsx
+++ b/packages/frontend/src/components/Form/Form.tsx
@@ -35,6 +35,10 @@ export const FormWrapper = styled.div`
   row-gap: 16px;
   padding: 82px 115px 82px 170px;
   width: 100%;
+
+  @media only screen and (max-width: 800px) {
+    padding: 82px 115px 82px 115px;
+  }
 `
 
 export const FormSectionWrapper = styled(FormWrapper)`

--- a/packages/frontend/src/components/Info/Accordion.tsx
+++ b/packages/frontend/src/components/Info/Accordion.tsx
@@ -227,6 +227,14 @@ const Wrapper = styled.div`
   max-width: 1252px;
   margin: 0 auto;
   padding: 68px 125px 68px 68px;
+
+  @media only screen and (max-width: 1024px) {
+    max-width: auto;
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: 32px;
+    padding-right: 32px;
+  }
 `
 const StyledHeader = styled(Accordion.Header)`
   width: 100%;

--- a/packages/frontend/src/components/Info/ClaimTicketTimeLeft.tsx
+++ b/packages/frontend/src/components/Info/ClaimTicketTimeLeft.tsx
@@ -27,7 +27,7 @@ interface TimeProps {
 }
 
 const ClaimTimeBox = styled.div<TimeProps>`
-  width: calc(100% - 54px);
+  //width: calc(100% - 54px);
   padding: 8px 24px 8px 68px;
   background: ${({ isPeriodExpired }) => (isPeriodExpired ? Colors.RedLight : Colors.Blue)};
 `

--- a/packages/frontend/src/components/Info/Header.tsx
+++ b/packages/frontend/src/components/Info/Header.tsx
@@ -42,6 +42,10 @@ const StyledHeader = styled(HeaderBar)`
 
   #background-image: url(${background});
   #background-size: cover;
+
+  @media only screen and (max-width: 800px) {
+    height: auto;
+  }
 `
 
 const HeaderWrapper = styled.div`

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -1,12 +1,20 @@
 import { Auction } from 'src/components/Auction'
+import { InfoAccordion } from 'src/components/Info/Accordion'
+import { Header } from 'src/components/Info/Header'
 import { Info } from 'src/components/Info/Info'
 import styled from 'styled-components'
+import { useWindowSize } from 'usehooks-ts'
 
 export function Home() {
+  const { width } = useWindowSize()
+  console.info({width})
+
   return (
-    <PageContainer>
-      <Info />
+    <PageContainer id="page-container">
+      { width >= 900 && <Info /> }
+      { width < 900 && <><Header />&nbsp;</> }
       <Auction />
+      { width < 900 && <InfoAccordion /> }
     </PageContainer>
   )
 }
@@ -15,4 +23,10 @@ const PageContainer = styled.div`
   display: flex;
   flex: 1;
   width: 100%;
+
+  @media only screen and (max-width: 768px) {
+    display: grid;
+    grid-template-columns: 1fr;
+    width: 100%;
+  }
 `

--- a/packages/frontend/src/styles/GlobalStyles.tsx
+++ b/packages/frontend/src/styles/GlobalStyles.tsx
@@ -8,6 +8,7 @@ export const GlobalStyles = createGlobalStyle`
 
   *, *:before, *:after {
     box-sizing: border-box;
+    font-size:calc(12px + 1.5vw);
   }
 
   html, body {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16799,6 +16799,11 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
+usehooks-ts@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/usehooks-ts/-/usehooks-ts-2.9.1.tgz#953d3284851ffd097432379e271ce046a8180b37"
+  integrity sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==
+
 utf-8-validate@5.0.7:
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.7.tgz#c15a19a6af1f7ad9ec7ddc425747ca28c3644922"


### PR DESCRIPTION
### Optimisation done in this PR

![Capture d’écran du 2023-03-23 10-14-52](https://user-images.githubusercontent.com/2432299/227156935-bbf1f648-bce0-4955-bbb8-3b4db7280dae.png)

On average:
- -14% for `bid`
- -27% for `bidWithDiscount`
- -20% for `claim`
- -31% for  `settleRaffle`

The users would certainly welcome that.

For the `Address.sendValue` instead of the built-in `.transfer()`, [I recommand you read that](https://consensys.net/diligence/blog/2019/09/stop-using-soliditys-transfer-now/). Its from 2019 ...

---
### Beyound this PR:

Its possible to go further (removing a lot of sloads) by doing the following changes, and storing the user addresses instead of the bidderId. You may even work without bidderId at all, using only addresses as identifiers. Such a drastic change would require deep change to the ABI/front/back, that I understand you deal with right now.


```diff
-    uint256[] _raffleParticipants;
-    uint256[] _auctionWinners;
-    uint256[] _raffleWinners;
+    address[] _raffleParticipants;
+    address[] _auctionWinners;
+    address[] _raffleWinners;
```